### PR TITLE
CB-3600 updating meridian framework

### DIFF
--- a/SDJSBridge/JavaScript API/Platform API/Dialog/Alert/SDJSAlertButton.h
+++ b/SDJSBridge/JavaScript API/Platform API/Dialog/Alert/SDJSAlertButton.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 
-NS_ENUM(NSInteger, SDJSAlertButtonType) {
+typedef NS_ENUM(NSInteger, SDJSAlertButtonType) {
     SDJSAlertButtonTypeOk,
     SDJSAlertButtonTypeCancel,
     SDJSAlertButtonTypeNeutral


### PR DESCRIPTION
This is needed so that we can turn on GCC_NO_COMMON_BLOCKS